### PR TITLE
Fixes #363

### DIFF
--- a/src/react-swipe.js
+++ b/src/react-swipe.js
@@ -149,7 +149,7 @@ class ReactSwipe extends Component {
       y: deltaY
     }, event);
 
-    if (shouldPreventDefault) {
+    if (shouldPreventDefault && event.cancelable) {
       event.preventDefault();
     }
 


### PR DESCRIPTION
Ignored attempt to cancel a touchmove event with cancelable=false
https://github.com/leandrowd/react-responsive-carousel/issues/363

https://stackoverflow.com/questions/26478267/touch-move-getting-stuck-ignored-attempt-to-cancel-a-touchmove